### PR TITLE
Notify observers when job batches are cancelled.

### DIFF
--- a/lib/plines/configuration.rb
+++ b/lib/plines/configuration.rb
@@ -10,6 +10,7 @@ module Plines
       batch_list_key { raise Error, "batch_list_key has not been configured" }
       qless_job_options { |job| {} }
       self.data_ttl_in_seconds = SIX_MONTHS_IN_SECONDS
+      @callbacks = Hash.new { |h, k| h[k] = [] }
     end
 
     def batch_list_key(&block)
@@ -29,6 +30,16 @@ module Plines
     attr_reader :qless_job_options_block
     def qless_job_options(&block)
       @qless_job_options_block = block
+    end
+
+    def after_job_batch_cancellation(&block)
+      @callbacks[:after_job_batch_cancellation] << block
+    end
+
+    def notify(callback_type, *args)
+      @callbacks[callback_type].each do |callback|
+        callback.call(*args)
+      end
     end
   end
 end

--- a/lib/plines/job_batch.rb
+++ b/lib/plines/job_batch.rb
@@ -143,6 +143,7 @@ module Plines
       pending_job_jids.each { |jid| cancel_job(jid) }
       meta["cancelled"] = "1"
       set_expiration!
+      pipeline.configuration.notify(:after_job_batch_cancellation, self)
     end
 
     def data

--- a/spec/unit/plines/configuration_spec.rb
+++ b/spec/unit/plines/configuration_spec.rb
@@ -50,6 +50,21 @@ module Plines
         expect(config.qless_job_options_block.call(stub)).to eq({})
       end
     end
+
+    describe "#after_job_batch_cancellation" do
+      let(:the_job_batch) { double }
+
+      it 'adds a callback that can be invoked via #notify(:after_job_batch_cancellation)' do
+        hook_1_batch = hook_2_batch = nil
+        config.after_job_batch_cancellation { |jb| hook_1_batch = jb }
+        config.after_job_batch_cancellation { |jb| hook_2_batch = jb }
+
+        config.notify(:after_job_batch_cancellation, the_job_batch)
+
+        expect(hook_1_batch).to be(the_job_batch)
+        expect(hook_2_batch).to be(the_job_batch)
+      end
+    end
   end
 end
 

--- a/spec/unit/plines/job_batch_spec.rb
+++ b/spec/unit/plines/job_batch_spec.rb
@@ -4,6 +4,7 @@ require 'plines/pipeline'
 require 'plines/step'
 require 'plines/enqueued_job'
 require 'plines/job_batch'
+require 'plines/configuration'
 
 module Plines
   describe JobBatch, :redis do
@@ -360,6 +361,15 @@ module Plines
 
         expect(P.redis.keys).not_to be_empty
         expect(expired_keys.to_a).to include(*P.redis.keys.grep(/job_batch/))
+      end
+
+      it 'notifies observers that it has been cancelled' do
+        notified_batch = nil
+        pipeline_module.configuration.after_job_batch_cancellation do |jb|
+          notified_batch = jb
+        end
+
+        expect { batch.cancel! }.to change { notified_batch }.from(nil).to(batch)
       end
     end
   end


### PR DESCRIPTION
This provides a simple way for observers to perform any needed cleanup at this point.

I plan to merge this once the travis build passes.
