### PR TITLE
Verify that the jobs we meant to cancel were cancelled.

### DIFF
--- a/spec/unit/plines/job_batch_spec.rb
+++ b/spec/unit/plines/job_batch_spec.rb
@@ -667,6 +667,20 @@ module Plines
         expect(default_queue.length).to eq(0)
       end
 
+      context 'when Qless silently fails to cancel some jobs' do
+        it 'raises an error to indicate the cancellation failure' do
+          qless.stub(:bulk_cancel) # to make it silent no-op
+          expect {
+            cancel
+          }.to raise_error(JobBatch::SomeJobsFailedToCancelError)
+        end
+      end
+
+      it 'does not consider a complete job to be a failed cancellation' do
+        default_queue.pop.complete
+        expect { cancel }.not_to raise_error
+      end
+
       it 'keeps track of whether or not cancellation has occurred' do
         expect(batch).not_to be_cancelled
         cancel


### PR DESCRIPTION
Not sure how this happened, but we've seen cases where the
job batch's meta indicates it was cancelled but the jobs
still remained. Might be a bug in Qless.

Regardless, we only want to consider the job batch as
cancelled if all jobs actually got cancelled (or were
already completed).
