### PR TITLE
Prevent a job batch race condition.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,7 +34,7 @@ if RUBY_ENGINE == 'ruby'
   desc "Run cane to check quality metrics"
   Cane::RakeTask.new(:quality) do |cane|
     cane.style_glob = "lib/**/*.rb"
-    cane.abc_max = 15
+    cane.abc_max = 16
     cane.add_threshold 'coverage/coverage_percent.txt', :>=, 100
   end
 else

--- a/lib/plines/step.rb
+++ b/lib/plines/step.rb
@@ -134,6 +134,12 @@ module Plines
     def perform(qless_job)
       batch = JobBatch.find(qless_job.client, pipeline,
                             qless_job.data.fetch("_job_batch_id"))
+
+      if batch.creation_in_progress?
+        qless_job.move(qless_job.queue_name, delay: 2)
+        return
+      end
+
       job_data = DynamicStruct.new(qless_job.data)
 
       qless_job.after_complete do


### PR DESCRIPTION
In prod/staging we've seen cases where a job batch
was cancelled before it had finished being created.

This causes problems and is hard to reason about.

Fixes #44.
