### PR TITLE
Make setting of job batch metadata atomic.

### DIFF
--- a/lib/plines/job_batch.rb
+++ b/lib/plines/job_batch.rb
@@ -247,7 +247,7 @@ module Plines
         creation_in_progress: 1
       }.merge(options)
 
-      meta.fill(metadata)
+      meta.bulk_set(metadata)
       @timeout_reduction = metadata.fetch(:timeout_reduction)
     end
 


### PR DESCRIPTION
In prod, we have some batches that have no `data`.
I believe this is because we were using `fill`, which
uses multiple `hsetnx` calls under the covers. This is
not atomic since it uses multiple redis calls. If it
got a timeout after the first one, the job batch would exist
(since the metadata hash would be in redis) but the data
could be nil.

The fix here makes this atomic, using `bulk_set` instead,
which uses `hmset` instead.
