### PR TITLE
Base `JobBatch#complete?` on the presence of `completed_at`.

### DIFF
--- a/lib/plines/job_batch.rb
+++ b/lib/plines/job_batch.rb
@@ -132,7 +132,7 @@ module Plines
     end
 
     def complete?
-      _complete?(pending_job_jids.length, completed_job_jids.length)
+      !!completed_at
     end
 
     def resolve_external_dependency(dep_name)
@@ -317,10 +317,6 @@ module Plines
       jids.each do |jid|
         EnqueuedJob.new(qless, pipeline, jid).send(meth, dep_name)
       end
-    end
-
-    def _complete?(pending_size, complete_size)
-      pending_size == 0 && complete_size > 0
     end
 
     def time_from(meta_entry)

--- a/spec/unit/plines/job_batch_spec.rb
+++ b/spec/unit/plines/job_batch_spec.rb
@@ -501,22 +501,15 @@ module Plines
     end
 
     describe "#complete?" do
-      it 'returns false when there are no pending or completed jobs' do
+      it 'returns true if the job batch has a completed_at timestamp' do
         batch = JobBatch.create(qless, pipeline_module, "foo", {})
-        expect(batch).not_to be_complete
-      end
-
-      it 'returns false when there are pending jobs and completed jobs' do
-        batch = JobBatch.create(qless, pipeline_module, "foo", {})
-        batch.pending_job_jids << "a"
-        batch.completed_job_jids << "b"
-        expect(batch).not_to be_complete
-      end
-
-      it 'returns true when there are only completed jobs' do
-        batch = JobBatch.create(qless, pipeline_module, "foo", {})
-        batch.completed_job_jids << "b"
+        batch.meta['completed_at'] = Time.now.getutc.iso8601
         expect(batch).to be_complete
+      end
+
+      it 'returns false if it lacks a completed_at timestamp' do
+        batch = JobBatch.create(qless, pipeline_module, "foo", {})
+        expect(batch).not_to be_complete
       end
     end
 
@@ -742,7 +735,7 @@ module Plines
       end
 
       it 'returns true for a complete job batch' do
-        batch.completed_job_jids << "a"
+        batch.meta['completed_at'] = Time.now.getutc.iso8601
         expect(batch.in_terminal_state?).to be_true
       end
 


### PR DESCRIPTION
The old logic was designed to figure out when to mark the
job batch as complete by setting the timestamp -- but
that has been moved into the lua script. Basing `complete?`
on the job jid sets is potentially risky since we have
discussed making some of the job batch redis keys expire
sooner than others. If the job jid set keys vanished from
redis the old logic would wrongly report the job batch
was not complete even though it was. The new logic
relies only on the `meta` key which is the primary key
used by a job batch to track its state.
