### PR TITLE
Use `JSON.parse`, not `JSON.load`.

### DIFF
--- a/lib/plines/job_batch.rb
+++ b/lib/plines/job_batch.rb
@@ -375,7 +375,7 @@ module Plines
     end
 
     def decode(string)
-      string && JSON.load(string)
+      string && JSON.parse(string)
     end
 
     def cancel_timeout_job_jid_set_for(dep_name)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,21 @@
 require_relative '../config/setup_load_paths'
 
+require 'json'
+module JSON
+  def self.load(*args)
+    raise <<-EOS
+JSON::load has been disabled for this project, as it can cause DoS and Unsafe Object
+Creation vulnerabilities if parsing untrusted input.
+
+To deserialize untrusted JSON, use JSON::parse.
+
+See https://groups.google.com/forum/?fromgroups=#!topic/rubyonrails-security/4_YvCpLzL58
+for more details about the vulnerability.
+    EOS
+  end
+end
+
+
 RSpec::Matchers.define :have_enqueued_waiting_jobs_for do |*klasses|
   match do |_|
     jobs = Plines.default_queue.peek(klasses.size + 1)

--- a/spec/unit/plines/job_batch_spec.rb
+++ b/spec/unit/plines/job_batch_spec.rb
@@ -177,7 +177,7 @@ module Plines
         batch.newly_added_external_deps << 'bar' << 'bazz' << 'bat' << 'foo'
         batch.populate_external_deps_meta {}
 
-        keys = JSON.load(batch.meta[JobBatch::EXT_DEP_KEYS_KEY])
+        keys = JSON.parse(batch.meta[JobBatch::EXT_DEP_KEYS_KEY])
         expect(keys).to match_array(%w[ foo bar bat bazz ])
       end
 


### PR DESCRIPTION
JSON.load is a security vulnerability since it can
load arbitrary ruby objects.
