### PR TITLE
Perf optimization.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -175,3 +175,22 @@ RSpec::Matchers.define :move_job do |jid|
   end
 end
 
+class RedisLogger < BasicObject
+  attr_reader :commands, :commands_with_args
+
+  def initialize(redis)
+    @redis    = redis
+    @commands = []
+    @commands_with_args = []
+  end
+
+  def respond_to_missing?(name, include_private = false)
+    @redis.respond_to?(name, include_private) || super
+  end
+
+  def method_missing(name, *args, &block)
+    @commands << name
+    @commands_with_args << [name, *args]
+    @redis.public_send(name, *args, &block)
+  end
+end

--- a/spec/unit/plines/job_batch_spec.rb
+++ b/spec/unit/plines/job_batch_spec.rb
@@ -116,24 +116,6 @@ module Plines
         end
       end
 
-      class RedisLogger < BasicObject
-        attr_reader :commands
-
-        def initialize(redis)
-          @redis    = redis
-          @commands = []
-        end
-
-        def respond_to_missing?(name, include_private = false)
-          @redis.respond_to?(name, include_private) || super
-        end
-
-        def method_missing(name, *args, &block)
-          @commands << name
-          @redis.public_send(name, *args, &block)
-        end
-      end
-
       it 'sets the metadata atomically to ensure a partial batch does not get created' do
         allow(qless).to receive_messages(redis: RedisLogger.new(redis))
         JobBatch.create(qless, pipeline_module, "a", { a: 5 }) { }


### PR DESCRIPTION
Previously, each time we enumerated a JobBatchList, we started
at 1 and counted up to the current counter value. This has gotten
slower and slower over time as the value of the counter has increased.

When we enumerate the list and find the first job batch at number n,
we know that there will never again be any job batches found at
numbers 1 through (n - 1), so we can safely skip those checks on
future enumerations. This is a safe assumption because

* New job batches get their number by incrementing the counter.
  Thus no new job batch could be created with a number lower than
  an existing job batch already has.
* Once a job batch is no longer in redis (whether or through expiration
  or a manual delete), it will never come back.