### PR TITLE
Start job batches atomically

### DIFF
--- a/lib/plines/atomic_job_batch_starter.rb
+++ b/lib/plines/atomic_job_batch_starter.rb
@@ -1,0 +1,30 @@
+module Plines
+  # Provides a way to atomically start multiple job batches.
+  class AtomicJobBatchStarter
+    def initialize(pipeline)
+      @pipeline = pipeline
+      @created_batches = []
+    end
+
+    def enqueue_jobs_for(batch_data, options = {}, &block)
+      @created_batches << @pipeline.enqueue_jobs_for(
+        batch_data, options.merge(leave_paused: true), &block
+      )
+    end
+
+    def atomically_start_created_batches
+      redises = @created_batches.map(&:redis).uniq
+      if redises.one?
+        redises.first.multi do
+          @created_batches.each(&:unpause)
+        end
+      else
+        raise MoreThanOneRedisServerError,
+          "Cannot atomically unpause batches from " \
+          "#{redises.count} redis servers"
+      end
+    end
+
+    MoreThanOneRedisServerError = Class.new(StandardError)
+  end
+end

--- a/lib/plines/job_batch.rb
+++ b/lib/plines/job_batch.rb
@@ -529,10 +529,9 @@ module Plines
 
         redis.multi do
           meta[:creation_completed_at] = Time.now.getutc.iso8601
-          meta.delete(:paused_retry_delay)
+          meta.delete(:paused_retry_delay) unless options[:leave_paused]
         end
       end
     end
   end
 end
-

--- a/lib/plines/job_batch.rb
+++ b/lib/plines/job_batch.rb
@@ -321,7 +321,7 @@ module Plines
 
     def get_user_data *keys
       if keys.size > 0
-        user_data.bulk_get *keys
+        user_data.bulk_get(*keys)
       else
         user_data.all
       end

--- a/lib/plines/job_batch.rb
+++ b/lib/plines/job_batch.rb
@@ -529,7 +529,7 @@ module Plines
 
         redis.multi do
           meta[:creation_completed_at] = Time.now.getutc.iso8601
-          meta.delete(:paused_retry_delay) unless options[:leave_paused]
+          unpause unless options[:leave_paused]
         end
       end
     end

--- a/lib/plines/job_batch.rb
+++ b/lib/plines/job_batch.rb
@@ -201,6 +201,25 @@ module Plines
       !!cancelled_at || (meta["cancelled"] == "1")
     end
 
+    DEFAULT_PAUSE_RETRY_DELAY = 30
+
+    def pause(retry_delay: DEFAULT_PAUSE_RETRY_DELAY)
+      meta["paused_retry_delay"] = retry_delay
+    end
+
+    def unpause
+      meta.delete("paused_retry_delay")
+    end
+
+    def paused?
+      !!paused_retry_delay
+    end
+
+    def paused_retry_delay
+      value = meta["paused_retry_delay"]
+      Integer(value) if value
+    end
+
     def creation_in_progress?
       meta_values = meta.bulk_get(:creation_completed_at,
                                   :created_at,
@@ -344,6 +363,7 @@ module Plines
         timeout_reduction: options.fetch(:timeout_reduction, 0),
         BATCH_DATA_KEY => JSON.dump(batch_data),
         CREATE_OPTIONS_KEY => JSON.dump(opts_to_store),
+        paused_retry_delay: DEFAULT_PAUSE_RETRY_DELAY,
       }
 
       if (reason = options[:reason])
@@ -506,7 +526,11 @@ module Plines
         populate_meta_for_create(batch_data, options)
 
         populate_external_deps_meta { yield self if block_given? }
-        meta[:creation_completed_at] = Time.now.getutc.iso8601
+
+        redis.multi do
+          meta[:creation_completed_at] = Time.now.getutc.iso8601
+          meta.delete(:paused_retry_delay)
+        end
       end
     end
   end

--- a/lib/plines/pipeline.rb
+++ b/lib/plines/pipeline.rb
@@ -1,6 +1,7 @@
 require 'qless'
 require 'forwardable'
 require 'plines/indifferent_hash'
+require 'plines/atomic_job_batch_starter'
 
 module Plines
   # This module should be extended onto a class or module in order
@@ -20,6 +21,12 @@ module Plines
 
     def configure
       yield configuration
+    end
+
+    def start_job_batches_atomically
+      starter = AtomicJobBatchStarter.new(self)
+      yield starter
+      starter.atomically_start_created_batches
     end
 
     def enqueue_jobs_for(batch_data, options = {})

--- a/lib/plines/step.rb
+++ b/lib/plines/step.rb
@@ -137,8 +137,8 @@ module Plines
       batch = JobBatch.find(qless_job.client, pipeline,
                             qless_job.data.fetch("_job_batch_id"))
 
-      if batch.creation_in_progress?
-        qless_job.move(qless_job.queue_name, delay: 2)
+      if (retry_delay = batch.paused_retry_delay)
+        qless_job.move(qless_job.queue_name, delay: retry_delay)
         return
       end
 

--- a/spec/integration/plines/start_job_batches_atomically_spec.rb
+++ b/spec/integration/plines/start_job_batches_atomically_spec.rb
@@ -1,0 +1,69 @@
+require 'plines'
+require 'delegate'
+
+RSpec.describe "Starting job batches atomically", :redis do
+  module MyPipeline
+    extend Plines::Pipeline
+
+    class MyStep
+      extend Plines::Step
+
+      fan_out do |data|
+        1.upto(data[:count]).map do |i|
+          { counter: i, simulate_timeout: (i == 3) }
+        end
+      end
+
+      def perform; end
+    end
+  end
+
+  class FlakeyRedis < DelegateClass(Redis)
+    def evalsha(sha, argv:, **rest)
+      return super unless argv.first == "put"
+
+      data = JSON.parse(argv[6])
+      if data["simulate_timeout"]
+        raise ::Redis::TimeoutError
+      else
+        super
+      end
+    end
+  end
+
+  let(:qless) { Qless::Client.new(redis: FlakeyRedis.new(redis)) }
+
+  before do
+    MyPipeline.configure do |plines|
+      plines.batch_list_key { "key" }
+      plines.qless_client   { qless }
+    end
+  end
+
+  def silence_warnings(&block)
+    expect(&block).to output(anything).to_stdout_from_any_process.and output(anything).to_stderr_from_any_process
+  end
+
+  it 'does not let any jobs run until the entire set of job batches have been fully created' do
+    expect {
+      silence_warnings do
+        MyPipeline.start_job_batches_atomically do |atomic_enqueuer|
+          atomic_enqueuer.enqueue_jobs_for(count: 2)
+          atomic_enqueuer.enqueue_jobs_for(count: 3)
+        end
+      end
+    }.to raise_error Redis::TimeoutError
+
+    jbs = MyPipeline.job_batch_list_for("key").to_a
+    expect(jbs.size).to eq(2)
+    expect(jbs).to all have_attributes(paused?: true)
+
+    MyPipeline.start_job_batches_atomically do |atomic_enqueuer|
+      atomic_enqueuer.enqueue_jobs_for(count: 2)
+      atomic_enqueuer.enqueue_jobs_for(count: 2)
+    end
+
+    jbs = MyPipeline.job_batch_list_for("key").to_a - jbs
+    expect(jbs).to all have_attributes(paused?: false)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -199,3 +199,5 @@ class RedisLogger < BasicObject
     @redis.public_send(name, *args, &block)
   end
 end
+
+RSpec::Matchers.define_negated_matcher :not_have_received, :have_received

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -108,6 +108,11 @@ RSpec.shared_context "redis", :redis do
       expect(job.jid).to eq(jid)
     end
   end
+
+  def job_scheduled_at(job)
+    # TODO: expose this from a Qless API
+    Time.at(job.client.redis.zscore("ql:q:#{job.queue_name}-scheduled", job.jid))
+  end
 end
 
 RSpec.shared_context "integration helpers" do

--- a/spec/unit/plines/atomic_job_batch_starter_spec.rb
+++ b/spec/unit/plines/atomic_job_batch_starter_spec.rb
@@ -1,0 +1,52 @@
+require 'plines/atomic_job_batch_starter'
+
+module Plines
+  RSpec.describe AtomicJobBatchStarter do
+    describe "#atomically_start_created_batches" do
+      def redis_double
+        instance_double("Redis").tap { |r| allow(r).to receive(:multi).and_yield }
+      end
+
+      let(:redis) { redis_double }
+      let(:jb1) { instance_double("Plines::JobBatch", redis: redis, unpause: nil) }
+      let(:jb2) { instance_double("Plines::JobBatch", redis: redis, unpause: nil) }
+      let(:pipeline) { instance_double("Plines::Pipeline") }
+
+      before do
+        allow(pipeline).to receive(:enqueue_jobs_for).and_return(jb1, jb2)
+      end
+
+      it 'unpauses the created batches using `multi` to ensure atomicity' do
+        expect(redis).to receive(:multi) do |&block|
+          expect([jb1, jb2]).to all not_have_received(:unpause)
+
+          block.call
+
+          expect([jb1, jb2]).to all have_received(:unpause)
+        end
+
+        starter = described_class.new(pipeline)
+        starter.enqueue_jobs_for({})
+        starter.enqueue_jobs_for({})
+
+        starter.atomically_start_created_batches
+      end
+
+      it 'raises a clear error if the job batches are for different redis connections since we cannot atomically unpause in that case' do
+        allow(jb1).to receive(:redis).and_return(redis_double)
+        allow(jb2).to receive(:redis).and_return(redis_double)
+
+        starter = described_class.new(pipeline)
+        starter.enqueue_jobs_for({})
+        starter.enqueue_jobs_for({})
+
+        expect {
+          starter.atomically_start_created_batches
+        }.to raise_error(AtomicJobBatchStarter::MoreThanOneRedisServerError)
+
+        expect(jb1).not_to have_received(:unpause)
+        expect(jb2).not_to have_received(:unpause)
+      end
+    end
+  end
+end

--- a/spec/unit/plines/job_batch_spec.rb
+++ b/spec/unit/plines/job_batch_spec.rb
@@ -75,6 +75,11 @@ module Plines
         expect(batch).not_to be_paused
       end
 
+      it 'leaves the job batch paused if `leave_paused: true` is passed' do
+        batch = JobBatch.create(qless, pipeline_module, "a", {}, leave_paused: true)
+        expect(batch).to be_paused
+      end
+
       describe "#create_options" do
         let(:special_options) do
           {


### PR DESCRIPTION
This adds a couple new APIs/features:

* pause/unpause functionality on a job batch
* The ability to atomically start multiple job batches