### PR TITLE
Address cancellation timeouts.

### DIFF
--- a/lib/plines/job_batch.rb
+++ b/lib/plines/job_batch.rb
@@ -427,7 +427,8 @@ module Plines
 
     def bulk_cancel_with_retry(jids, tries=4, delay=0.25)
       qless.bulk_cancel(jids)
-    rescue Redis::BaseConnectionError # base class of TimeoutError and ConnectionError
+    rescue Redis::BaseConnectionError # base class of TimeoutError
+                                      # and ConnectionError
       raise if (tries -= 1).zero?
       sleep(delay *= 2)
       retry


### PR DESCRIPTION
For large batches it is very painful to have a cancellation
timeout, because it spends a long time preparing for it
(doing a topological sort of all jobs), which forces us
to re-do all that work when we retry. Better to have some
simple retries in place for the actual `bulk_cancel` call.